### PR TITLE
feat(mobile): cards/blocking, menjačnica, kursna lista, loans, per-card tx (todoSpec)

### DIFF
--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -26,6 +26,18 @@ export default function AppLayout() {
         name="racuni"
         options={{ title: "Računi", headerShown: false }}
       />
+      <Tabs.Screen
+        name="kartice"
+        options={{ title: "Kartice", headerShown: false }}
+      />
+      <Tabs.Screen
+        name="krediti"
+        options={{ title: "Krediti", headerShown: false }}
+      />
+      <Tabs.Screen
+        name="menjacnica"
+        options={{ title: "Menjačnica", headerShown: false }}
+      />
     </Tabs>
   );
 }

--- a/app/(app)/kartice/[id].tsx
+++ b/app/(app)/kartice/[id].tsx
@@ -1,0 +1,212 @@
+import { useState } from "react";
+import {
+  Alert,
+  FlatList,
+  RefreshControl,
+  Text,
+  View,
+} from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+import { blockCard, listCards, listCardTransactions } from "@/lib/api/cards";
+import { apiError } from "@/lib/api/error";
+import { keys } from "@/lib/query-keys";
+import { brandLabel, statusMeta } from "@/lib/cards-meta";
+import { formatDate, formatMoney } from "@/lib/format";
+import {
+  Badge,
+  Button,
+  Card,
+  LoadingState,
+  MessageState,
+  Screen,
+} from "@/components/ui";
+import { v1CardStatus } from "@/lib/api/generated";
+
+const PAGE_SIZE = 10;
+
+// Card detail (todoSpec mobile). Shows the card + its transactions
+// (the card's account ledger, paginated), and lets the client BLOCK an
+// active card. Blocking is one-way here: unblocking is done in branch /
+// by phone (spec), so we never offer the reverse action.
+export default function CardDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const cardId = id ?? "";
+  const qc = useQueryClient();
+  const [page, setPage] = useState(0);
+
+  // The list endpoint is the only card read (no GET /cards/{id}); we pick
+  // the card out of it. Cheap, and keeps one cache for both screens.
+  const cardsQ = useQuery({
+    queryKey: keys.cards.list(),
+    queryFn: () => listCards(),
+  });
+  const card = cardsQ.data?.find((c) => c.id === cardId);
+  const accountId = card?.accountId ?? "";
+
+  const txQ = useQuery({
+    queryKey: keys.cards.transactions(accountId, page),
+    queryFn: () => listCardTransactions(accountId, page, PAGE_SIZE),
+    enabled: !!accountId,
+  });
+
+  const block = useMutation({
+    mutationFn: () => blockCard(cardId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: keys.cards.all() });
+    },
+    onError: (err) => {
+      Alert.alert("Greška", apiError(err, "Blokiranje kartice nije uspelo."));
+    },
+  });
+
+  if (cardsQ.isLoading) return <LoadingState />;
+  if (cardsQ.isError || !card)
+    return (
+      <Screen>
+        <MessageState message="Nije moguće učitati karticu." />
+      </Screen>
+    );
+
+  const meta =
+    statusMeta[card.status ?? v1CardStatus.CARD_STATUS_UNSPECIFIED] ??
+    statusMeta[v1CardStatus.CARD_STATUS_UNSPECIFIED]!;
+  const isActive = card.status === v1CardStatus.CARD_STATUS_ACTIVE;
+
+  const transactions = [...(txQ.data?.transactions ?? [])].sort(
+    (x, y) =>
+      new Date(y.createdAt ?? 0).getTime() -
+      new Date(x.createdAt ?? 0).getTime(),
+  );
+  const total = Number(txQ.data?.total ?? "0");
+  const hasNext = (page + 1) * PAGE_SIZE < total;
+
+  const confirmBlock = () => {
+    Alert.alert(
+      "Blokiranje kartice",
+      "Da li ste sigurni? Karticu kasnije odblokirate u ekspozituri ili pozivom banke.",
+      [
+        { text: "Odustani", style: "cancel" },
+        {
+          text: "Blokiraj",
+          style: "destructive",
+          onPress: () => block.mutate(),
+        },
+      ],
+    );
+  };
+
+  return (
+    <Screen>
+      <Card>
+        <View className="flex-row justify-between items-start">
+          <View className="flex-1 pr-3">
+            <Text className="text-slate-900 font-semibold text-lg">
+              {card.name || "Kartica"}
+            </Text>
+            <Text className="text-slate-500 text-sm mt-1">
+              {brandLabel(card.brand)}
+            </Text>
+            <Text className="text-slate-500 text-sm mt-0.5">{card.number}</Text>
+          </View>
+          <Badge label={meta.label} tone={meta.tone} />
+        </View>
+        {card.cardLimit ? (
+          <Text className="text-slate-400 text-xs mt-3">
+            Limit: {formatMoney(card.cardLimit)}
+          </Text>
+        ) : null}
+        {card.expiresAt ? (
+          <Text className="text-slate-400 text-xs mt-0.5">
+            Važi do: {formatDate(card.expiresAt)}
+          </Text>
+        ) : null}
+      </Card>
+
+      {isActive ? (
+        <View className="mb-3">
+          <Button
+            label="Blokiraj karticu"
+            variant="ghost"
+            loading={block.isPending}
+            onPress={confirmBlock}
+          />
+        </View>
+      ) : null}
+
+      <Text className="text-slate-700 font-semibold mb-2 mt-1">Transakcije</Text>
+
+      {txQ.isLoading ? (
+        <LoadingState />
+      ) : transactions.length === 0 ? (
+        <MessageState message="Nema transakcija." />
+      ) : (
+        <FlatList
+          data={transactions}
+          keyExtractor={(t, i) => t.id ?? String(i)}
+          refreshControl={
+            <RefreshControl
+              refreshing={txQ.isRefetching}
+              onRefresh={() => void txQ.refetch()}
+            />
+          }
+          renderItem={({ item }) => {
+            const outgoing = item.fromAccountId === accountId;
+            const amount = outgoing ? item.fromAmount : item.toAmount;
+            return (
+              <Card>
+                <View className="flex-row justify-between">
+                  <View className="flex-1 pr-3">
+                    <Text className="text-slate-900">
+                      {item.purpose || item.recipientName || "Transakcija"}
+                    </Text>
+                    <Text className="text-slate-400 text-xs mt-0.5">
+                      {formatDate(item.createdAt)}
+                    </Text>
+                  </View>
+                  <Text
+                    className={
+                      outgoing
+                        ? "text-red-600 font-semibold"
+                        : "text-emerald-600 font-semibold"
+                    }
+                  >
+                    {outgoing ? "-" : "+"}
+                    {formatMoney(amount)}
+                  </Text>
+                </View>
+              </Card>
+            );
+          }}
+          ListFooterComponent={
+            page > 0 || hasNext ? (
+              <View className="flex-row justify-between gap-3 mt-1 mb-4">
+                <View className="flex-1">
+                  <Button
+                    label="Prethodna"
+                    variant="ghost"
+                    disabled={page === 0}
+                    onPress={() => setPage((p) => Math.max(0, p - 1))}
+                  />
+                </View>
+                <View className="flex-1">
+                  <Button
+                    label="Sledeća"
+                    variant="ghost"
+                    disabled={!hasNext}
+                    onPress={() => setPage((p) => p + 1)}
+                  />
+                </View>
+              </View>
+            ) : null
+          }
+        />
+      )}
+    </Screen>
+  );
+}

--- a/app/(app)/kartice/_layout.tsx
+++ b/app/(app)/kartice/_layout.tsx
@@ -1,0 +1,10 @@
+import { Stack } from "expo-router";
+
+export default function KarticeLayout() {
+  return (
+    <Stack screenOptions={{ headerStyle: { backgroundColor: "#f8fafc" } }}>
+      <Stack.Screen name="index" options={{ title: "Kartice" }} />
+      <Stack.Screen name="[id]" options={{ title: "Detalji kartice" }} />
+    </Stack>
+  );
+}

--- a/app/(app)/kartice/index.tsx
+++ b/app/(app)/kartice/index.tsx
@@ -1,0 +1,88 @@
+import { FlatList, Pressable, RefreshControl, Text, View } from "react-native";
+import { Link } from "expo-router";
+import { useQuery } from "@tanstack/react-query";
+
+import { listCards } from "@/lib/api/cards";
+import { keys } from "@/lib/query-keys";
+import { formatMoney } from "@/lib/format";
+import {
+  Badge,
+  type BadgeTone,
+  Card,
+  LoadingState,
+  MessageState,
+  Screen,
+} from "@/components/ui";
+import { v1CardStatus } from "@/lib/api/generated";
+import { brandLabel, statusMeta } from "@/lib/cards-meta";
+
+// Card list (todoSpec mobile). Tapping a card opens its detail, where it
+// can be blocked and its transactions viewed. Numbers come back masked
+// for clients (4111********1111) — we display them as-is.
+export default function KarticeScreen() {
+  const { data, isLoading, isError, isRefetching, refetch } = useQuery({
+    queryKey: keys.cards.list(),
+    queryFn: () => listCards(),
+  });
+
+  if (isLoading) return <LoadingState />;
+  if (isError)
+    return (
+      <Screen>
+        <MessageState message="Nije moguće učitati kartice." />
+      </Screen>
+    );
+
+  const cards = data ?? [];
+
+  return (
+    <Screen>
+      {cards.length === 0 ? (
+        <MessageState message="Nemate kartica." />
+      ) : (
+        <FlatList
+          data={cards}
+          keyExtractor={(c, i) => c.id ?? String(i)}
+          refreshControl={
+            <RefreshControl
+              refreshing={isRefetching}
+              onRefresh={() => void refetch()}
+            />
+          }
+          renderItem={({ item }) => {
+            const meta =
+              statusMeta[item.status ?? v1CardStatus.CARD_STATUS_UNSPECIFIED] ??
+              ({ label: "—", tone: "neutral" } as {
+                label: string;
+                tone: BadgeTone;
+              });
+            return (
+              <Link href={`/(app)/kartice/${item.id}`} asChild>
+                <Pressable>
+                  <Card>
+                    <View className="flex-row justify-between items-start">
+                      <View className="flex-1 pr-3">
+                        <Text className="text-slate-900 font-semibold">
+                          {item.name || "Kartica"}
+                        </Text>
+                        <Text className="text-slate-500 text-xs mt-0.5">
+                          {brandLabel(item.brand)} · {item.number}
+                        </Text>
+                      </View>
+                      <Badge label={meta.label} tone={meta.tone} />
+                    </View>
+                    {item.cardLimit ? (
+                      <Text className="text-slate-400 text-xs mt-2">
+                        Limit: {formatMoney(item.cardLimit)}
+                      </Text>
+                    ) : null}
+                  </Card>
+                </Pressable>
+              </Link>
+            );
+          }}
+        />
+      )}
+    </Screen>
+  );
+}

--- a/app/(app)/krediti/[id].tsx
+++ b/app/(app)/krediti/[id].tsx
@@ -1,0 +1,162 @@
+import { FlatList, RefreshControl, Text, View } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import { useQuery } from "@tanstack/react-query";
+
+import { getLoan } from "@/lib/api/loans";
+import { keys } from "@/lib/query-keys";
+import {
+  installmentStatusMeta,
+  loanStatusMeta,
+  loanTypeLabel,
+} from "@/lib/loans-meta";
+import { currencyLabel, formatDate, formatMoney } from "@/lib/format";
+import {
+  Badge,
+  Card,
+  LoadingState,
+  MessageState,
+  Screen,
+} from "@/components/ui";
+import { v1InstallmentStatus, v1LoanStatus } from "@/lib/api/generated";
+
+// Loan detail (todoSpec mobile). Header summarises the loan + the
+// upcoming installment; the list below is the full repayment schedule.
+export default function LoanDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const loanId = id ?? "";
+
+  const { data, isLoading, isError, isRefetching, refetch } = useQuery({
+    queryKey: keys.loans.detail(loanId),
+    queryFn: () => getLoan(loanId),
+    enabled: !!loanId,
+  });
+
+  if (isLoading) return <LoadingState />;
+  if (isError || !data?.loan)
+    return (
+      <Screen>
+        <MessageState message="Nije moguće učitati kredit." />
+      </Screen>
+    );
+
+  const loan = data.loan;
+  const cur = currencyLabel(loan.currency);
+  const meta =
+    loanStatusMeta[loan.status ?? v1LoanStatus.LOAN_STATUS_UNSPECIFIED] ??
+    loanStatusMeta[v1LoanStatus.LOAN_STATUS_UNSPECIFIED]!;
+  const installments = [...(data.installments ?? [])].sort(
+    (a, b) => (a.sequenceNumber ?? 0) - (b.sequenceNumber ?? 0),
+  );
+
+  return (
+    <Screen>
+      <Card>
+        <View className="flex-row justify-between items-start">
+          <View className="flex-1 pr-3">
+            <Text className="text-slate-900 font-semibold text-lg">
+              {loanTypeLabel(loan.loanType)}
+            </Text>
+            <Text className="text-slate-500 text-xs mt-0.5">
+              {loan.loanNumber}
+            </Text>
+          </View>
+          <Badge label={meta.label} tone={meta.tone} />
+        </View>
+
+        <View className="flex-row justify-between mt-4">
+          <Text className="text-slate-500 text-sm">Iznos kredita</Text>
+          <Text className="text-slate-900 text-sm">
+            {formatMoney(loan.principal, cur)}
+          </Text>
+        </View>
+        <View className="flex-row justify-between mt-1">
+          <Text className="text-slate-500 text-sm">Preostali dug</Text>
+          <Text className="text-slate-900 text-sm font-semibold">
+            {formatMoney(loan.remainingPrincipal, cur)}
+          </Text>
+        </View>
+        {loan.effectiveRate ? (
+          <View className="flex-row justify-between mt-1">
+            <Text className="text-slate-500 text-sm">Nominalna kamata</Text>
+            <Text className="text-slate-900 text-sm">
+              {loan.effectiveRate}%
+            </Text>
+          </View>
+        ) : null}
+        {loan.maturesAt ? (
+          <View className="flex-row justify-between mt-1">
+            <Text className="text-slate-500 text-sm">Datum dospeća</Text>
+            <Text className="text-slate-900 text-sm">
+              {formatDate(loan.maturesAt)}
+            </Text>
+          </View>
+        ) : null}
+      </Card>
+
+      {loan.nextInstallmentAmount ? (
+        <Card>
+          <Text className="text-slate-500 text-sm">Sledeća rata</Text>
+          <Text className="text-2xl font-bold text-slate-900 mt-1">
+            {formatMoney(loan.nextInstallmentAmount, cur)}
+          </Text>
+          {loan.nextInstallmentDate ? (
+            <Text className="text-slate-400 text-xs mt-1">
+              Dospeva: {formatDate(loan.nextInstallmentDate)}
+            </Text>
+          ) : null}
+        </Card>
+      ) : null}
+
+      <Text className="text-slate-700 font-semibold mb-2 mt-1">
+        Plan otplate
+      </Text>
+
+      {installments.length === 0 ? (
+        <MessageState message="Nema rata." />
+      ) : (
+        <FlatList
+          data={installments}
+          keyExtractor={(it, i) => it.id ?? String(i)}
+          refreshControl={
+            <RefreshControl
+              refreshing={isRefetching}
+              onRefresh={() => void refetch()}
+            />
+          }
+          renderItem={({ item }) => {
+            const im =
+              installmentStatusMeta[
+                item.status ??
+                  v1InstallmentStatus.INSTALLMENT_STATUS_UNSPECIFIED
+              ] ??
+              installmentStatusMeta[
+                v1InstallmentStatus.INSTALLMENT_STATUS_UNSPECIFIED
+              ]!;
+            return (
+              <Card>
+                <View className="flex-row justify-between items-start">
+                  <View className="flex-1 pr-3">
+                    <Text className="text-slate-900">
+                      Rata {item.sequenceNumber}
+                    </Text>
+                    <Text className="text-slate-400 text-xs mt-0.5">
+                      Dospeva: {formatDate(item.expectedDueDate)}
+                    </Text>
+                  </View>
+                  <View className="items-end">
+                    <Text className="text-slate-900 font-semibold">
+                      {formatMoney(item.amount, currencyLabel(item.currency))}
+                    </Text>
+                    <View className="mt-1">
+                      <Badge label={im.label} tone={im.tone} />
+                    </View>
+                  </View>
+                </View>
+              </Card>
+            );
+          }}
+        />
+      )}
+    </Screen>
+  );
+}

--- a/app/(app)/krediti/_layout.tsx
+++ b/app/(app)/krediti/_layout.tsx
@@ -1,0 +1,10 @@
+import { Stack } from "expo-router";
+
+export default function KreditiLayout() {
+  return (
+    <Stack screenOptions={{ headerStyle: { backgroundColor: "#f8fafc" } }}>
+      <Stack.Screen name="index" options={{ title: "Krediti" }} />
+      <Stack.Screen name="[id]" options={{ title: "Detalji kredita" }} />
+    </Stack>
+  );
+}

--- a/app/(app)/krediti/index.tsx
+++ b/app/(app)/krediti/index.tsx
@@ -1,0 +1,107 @@
+import { FlatList, Pressable, RefreshControl, Text, View } from "react-native";
+import { Link } from "expo-router";
+import { useQuery } from "@tanstack/react-query";
+
+import { listLoans } from "@/lib/api/loans";
+import { useAuthStore } from "@/lib/auth/store";
+import { keys } from "@/lib/query-keys";
+import { loanStatusMeta, loanTypeLabel } from "@/lib/loans-meta";
+import { currencyLabel, formatDate, formatMoney } from "@/lib/format";
+import {
+  Badge,
+  Card,
+  LoadingState,
+  MessageState,
+  Screen,
+} from "@/components/ui";
+import { v1LoanStatus } from "@/lib/api/generated";
+
+// Loan list (todoSpec mobile). Each row surfaces the upcoming
+// installment amount + due date at a glance; the detail shows the full
+// schedule. Read-only — applying for a loan stays on the web app.
+export default function KreditiScreen() {
+  const userId = useAuthStore((s) => s.identity?.userId ?? "");
+
+  const { data, isLoading, isError, isRefetching, refetch } = useQuery({
+    queryKey: keys.loans.list(),
+    queryFn: () => listLoans(userId),
+    enabled: !!userId,
+  });
+
+  if (isLoading) return <LoadingState />;
+  if (isError)
+    return (
+      <Screen>
+        <MessageState message="Nije moguće učitati kredite." />
+      </Screen>
+    );
+
+  const loans = data ?? [];
+
+  return (
+    <Screen>
+      {loans.length === 0 ? (
+        <MessageState message="Nemate kredita." />
+      ) : (
+        <FlatList
+          data={loans}
+          keyExtractor={(l, i) => l.id ?? l.loanNumber ?? String(i)}
+          refreshControl={
+            <RefreshControl
+              refreshing={isRefetching}
+              onRefresh={() => void refetch()}
+            />
+          }
+          renderItem={({ item }) => {
+            const meta =
+              loanStatusMeta[
+                item.status ?? v1LoanStatus.LOAN_STATUS_UNSPECIFIED
+              ] ?? loanStatusMeta[v1LoanStatus.LOAN_STATUS_UNSPECIFIED]!;
+            const cur = currencyLabel(item.currency);
+            return (
+              <Link href={`/(app)/krediti/${item.id}`} asChild>
+                <Pressable>
+                  <Card>
+                    <View className="flex-row justify-between items-start">
+                      <View className="flex-1 pr-3">
+                        <Text className="text-slate-900 font-semibold">
+                          {loanTypeLabel(item.loanType)}
+                        </Text>
+                        <Text className="text-slate-500 text-xs mt-0.5">
+                          {item.loanNumber}
+                        </Text>
+                      </View>
+                      <Badge label={meta.label} tone={meta.tone} />
+                    </View>
+
+                    <View className="flex-row justify-between mt-3">
+                      <Text className="text-slate-500 text-xs">
+                        Preostali dug
+                      </Text>
+                      <Text className="text-slate-900 text-sm font-semibold">
+                        {formatMoney(item.remainingPrincipal, cur)}
+                      </Text>
+                    </View>
+                    {item.nextInstallmentAmount ? (
+                      <View className="flex-row justify-between mt-1">
+                        <Text className="text-slate-500 text-xs">
+                          Sledeća rata
+                          {item.nextInstallmentDate
+                            ? ` (${formatDate(item.nextInstallmentDate)})`
+                            : ""}
+                        </Text>
+                        <Text className="text-slate-900 text-sm font-semibold">
+                          {formatMoney(item.nextInstallmentAmount, cur)}
+                        </Text>
+                      </View>
+                    ) : null}
+                  </Card>
+                </Pressable>
+              </Link>
+            );
+          }}
+        />
+      )}
+    </Screen>
+  );
+}

--- a/app/(app)/menjacnica/_layout.tsx
+++ b/app/(app)/menjacnica/_layout.tsx
@@ -1,0 +1,10 @@
+import { Stack } from "expo-router";
+
+export default function MenjacnicaLayout() {
+  return (
+    <Stack screenOptions={{ headerStyle: { backgroundColor: "#f8fafc" } }}>
+      <Stack.Screen name="index" options={{ title: "Menjačnica" }} />
+      <Stack.Screen name="kursna-lista" options={{ title: "Kursna lista" }} />
+    </Stack>
+  );
+}

--- a/app/(app)/menjacnica/index.tsx
+++ b/app/(app)/menjacnica/index.tsx
@@ -1,0 +1,303 @@
+import { useMemo, useState } from "react";
+import {
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { Link } from "expo-router";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+import { listAccounts } from "@/lib/api/accounts";
+import { quoteExchange, executeExchange } from "@/lib/api/exchange";
+import {
+  requestVerification,
+  type IssuedVerification,
+} from "@/lib/api/verification";
+import { apiError } from "@/lib/api/error";
+import { useAuthStore } from "@/lib/auth/store";
+import { keys } from "@/lib/query-keys";
+import { currencyLabel, formatMoney, formatRate } from "@/lib/format";
+import { Button, Card, LoadingState, MessageState, Screen } from "@/components/ui";
+import type { v1Account } from "@/lib/api/generated";
+
+const AMOUNT_RE = /^[0-9]+(\.[0-9]{1,2})?$/;
+
+// Menjačnica (todoSpec mobile). Pick two own accounts of different
+// currencies + an amount, see the live quote (rate, commission,
+// resulting amount), then execute. Execute is a verification-gated
+// CrossCurrency transfer (spec p.11): the screen requests a code, shows
+// it (spec Option 1, same as the web fake-QR), the user confirms, and we
+// attach the proof. The bank routes the FX via RSD internally.
+export default function MenjacnicaScreen() {
+  const userId = useAuthStore((s) => s.identity?.userId ?? "");
+  const qc = useQueryClient();
+
+  const [fromId, setFromId] = useState("");
+  const [toId, setToId] = useState("");
+  const [amount, setAmount] = useState("");
+  const [issued, setIssued] = useState<IssuedVerification | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const accountsQ = useQuery({
+    queryKey: keys.accounts.list(),
+    queryFn: () => listAccounts(userId),
+    enabled: !!userId,
+  });
+  const accounts = accountsQ.data ?? [];
+  const fromAcc = accounts.find((a) => a.id === fromId);
+  const toAcc = accounts.find((a) => a.id === toId);
+
+  const amountValid = AMOUNT_RE.test(amount) && Number(amount) > 0;
+  const sameCurrency =
+    !!fromAcc && !!toAcc && fromAcc.currency === toAcc.currency;
+  const quoteEnabled =
+    !!fromAcc?.currency &&
+    !!toAcc?.currency &&
+    !sameCurrency &&
+    amountValid;
+
+  const quote = useQuery({
+    queryKey: keys.exchange.quote(
+      fromAcc?.currency ?? "",
+      toAcc?.currency ?? "",
+      amount,
+    ),
+    queryFn: () =>
+      quoteExchange({
+        from: fromAcc!.currency,
+        to: toAcc!.currency,
+        amount,
+        includeCommission: true,
+      }),
+    enabled: quoteEnabled,
+  });
+
+  const exec = useMutation({
+    mutationFn: async (issuedCode: IssuedVerification) => {
+      return executeExchange(
+        { fromAccountId: fromId, toAccountId: toId, amount },
+        { id: issuedCode.verificationId, code: issuedCode.code },
+      );
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: keys.accounts.all() });
+      setIssued(null);
+      setAmount("");
+      setError(null);
+    },
+    onError: (err) => setError(apiError(err, "Zamena valuta nije uspela.")),
+  });
+
+  const startVerify = useMutation({
+    mutationFn: () => requestVerification("transfer"),
+    onSuccess: (data) => {
+      setError(null);
+      setIssued(data);
+    },
+    onError: (err) =>
+      setError(apiError(err, "Pokretanje verifikacije nije uspelo.")),
+  });
+
+  const canSubmit = quoteEnabled && !!quote.data && !quote.isFetching;
+
+  if (accountsQ.isLoading) return <LoadingState />;
+  if (accountsQ.isError)
+    return (
+      <Screen>
+        <MessageState message="Nije moguće učitati račune." />
+      </Screen>
+    );
+
+  return (
+    <Screen>
+      <ScrollView keyboardShouldPersistTaps="handled">
+        <AccountPicker
+          label="Sa računa"
+          accounts={accounts}
+          selectedId={fromId}
+          onSelect={setFromId}
+        />
+        <AccountPicker
+          label="Na račun"
+          accounts={accounts}
+          selectedId={toId}
+          onSelect={setToId}
+        />
+
+        <Text className="text-slate-700 mb-1 font-medium">
+          Iznos {fromAcc ? `(${currencyLabel(fromAcc.currency)})` : ""}
+        </Text>
+        <TextInput
+          className="border border-slate-300 rounded-xl px-4 py-3 bg-white mb-3"
+          placeholder="0,00"
+          keyboardType="decimal-pad"
+          value={amount}
+          onChangeText={(t) => setAmount(t.replace(",", "."))}
+          editable={!issued}
+        />
+
+        {sameCurrency ? (
+          <Text className="text-amber-700 text-sm mb-3">
+            Računi imaju istu valutu — za istu valutu koristite veb aplikaciju.
+          </Text>
+        ) : null}
+
+        {quote.data ? (
+          <Card>
+            <Row label="Kurs" value={formatRate(quote.data.rate)} />
+            <Row
+              label="Provizija"
+              value={formatMoney(
+                quote.data.commission,
+                currencyLabel(toAcc?.currency),
+              )}
+            />
+            <Row
+              label="Dobijate"
+              value={formatMoney(
+                quote.data.toAmount,
+                currencyLabel(toAcc?.currency),
+              )}
+              strong
+            />
+          </Card>
+        ) : null}
+
+        {error ? <Text className="text-red-600 mb-3">{error}</Text> : null}
+
+        {issued ? (
+          <Card>
+            <Text className="text-slate-500 text-sm">
+              Verifikacioni kod (unesite ga ovde da potvrdite)
+            </Text>
+            <Text className="text-4xl font-bold tracking-widest text-slate-900 my-2">
+              {issued.code}
+            </Text>
+            <Text className="text-slate-400 text-xs mb-3">
+              Potvrdom premeštate {formatMoney(amount, currencyLabel(fromAcc?.currency))} u{" "}
+              {currencyLabel(toAcc?.currency)}.
+            </Text>
+            <Button
+              label="Potvrdi zamenu"
+              loading={exec.isPending}
+              onPress={() => exec.mutate(issued)}
+            />
+            <View className="mt-2">
+              <Button
+                label="Odustani"
+                variant="ghost"
+                disabled={exec.isPending}
+                onPress={() => {
+                  setIssued(null);
+                  setError(null);
+                }}
+              />
+            </View>
+          </Card>
+        ) : (
+          <Button
+            label="Realizuj"
+            loading={startVerify.isPending}
+            disabled={!canSubmit}
+            onPress={() => startVerify.mutate()}
+          />
+        )}
+
+        <View className="mt-4 mb-6">
+          <Link href="/(app)/menjacnica/kursna-lista" asChild>
+            <Pressable>
+              <Text className="text-sky-600 text-center font-medium">
+                Pogledaj kursnu listu
+              </Text>
+            </Pressable>
+          </Link>
+        </View>
+      </ScrollView>
+    </Screen>
+  );
+}
+
+function Row({
+  label,
+  value,
+  strong,
+}: {
+  label: string;
+  value: string;
+  strong?: boolean;
+}) {
+  return (
+    <View className="flex-row justify-between py-0.5">
+      <Text className="text-slate-500 text-sm">{label}</Text>
+      <Text
+        className={
+          strong
+            ? "text-slate-900 font-bold"
+            : "text-slate-900 text-sm font-medium"
+        }
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+function AccountPicker({
+  label,
+  accounts,
+  selectedId,
+  onSelect,
+}: {
+  label: string;
+  accounts: v1Account[];
+  selectedId: string;
+  onSelect: (id: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = useMemo(
+    () => accounts.find((a) => a.id === selectedId),
+    [accounts, selectedId],
+  );
+  return (
+    <View className="mb-3">
+      <Text className="text-slate-700 mb-1 font-medium">{label}</Text>
+      <Pressable
+        className="border border-slate-300 rounded-xl px-4 py-3 bg-white"
+        onPress={() => setOpen((o) => !o)}
+      >
+        <Text className={selected ? "text-slate-900" : "text-slate-400"}>
+          {selected
+            ? `${selected.number} · ${currencyLabel(selected.currency)}`
+            : "— izaberite račun —"}
+        </Text>
+      </Pressable>
+      {open ? (
+        <View className="border border-slate-200 rounded-xl mt-1 bg-white overflow-hidden">
+          {accounts.map((a) => (
+            <Pressable
+              key={a.id}
+              className="px-4 py-3 border-b border-slate-100 active:bg-slate-50"
+              onPress={() => {
+                onSelect(a.id ?? "");
+                setOpen(false);
+              }}
+            >
+              <Text className="text-slate-900">
+                {a.number} · {currencyLabel(a.currency)}
+              </Text>
+              <Text className="text-slate-400 text-xs mt-0.5">
+                {formatMoney(a.availableBalance, currencyLabel(a.currency))}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+}

--- a/app/(app)/menjacnica/kursna-lista.tsx
+++ b/app/(app)/menjacnica/kursna-lista.tsx
@@ -1,0 +1,84 @@
+import { FlatList, RefreshControl, Text, View } from "react-native";
+import { useQuery } from "@tanstack/react-query";
+
+import { listRates } from "@/lib/api/rates";
+import { keys } from "@/lib/query-keys";
+import { currencyLabel, formatDateTime, formatRate } from "@/lib/format";
+import { Card, LoadingState, MessageState, Screen } from "@/components/ui";
+import { bankaExchangeV1Currency } from "@/lib/api/generated";
+
+// Kursna lista (todoSpec mobile). Current rate list, RSD pairs only
+// (the dimension a client cares about), kupovni (bid) / prodajni (ask)
+// like the web app. Read-only; reuses GET /v1/exchange/rates.
+export default function KursnaListaScreen() {
+  const { data, isLoading, isError, isRefetching, refetch } = useQuery({
+    queryKey: keys.rates.all(),
+    queryFn: () => listRates(),
+  });
+
+  if (isLoading) return <LoadingState />;
+  if (isError)
+    return (
+      <Screen>
+        <MessageState message="Kursna lista trenutno nije dostupna." />
+      </Screen>
+    );
+
+  const rates = (data ?? []).filter(
+    (r) =>
+      r.from === bankaExchangeV1Currency.CURRENCY_RSD ||
+      r.to === bankaExchangeV1Currency.CURRENCY_RSD,
+  );
+
+  return (
+    <Screen>
+      {rates.length === 0 ? (
+        <MessageState message="Kursna lista trenutno nije dostupna." />
+      ) : (
+        <FlatList
+          data={rates}
+          keyExtractor={(r, i) => `${r.from}-${r.to}-${i}`}
+          refreshControl={
+            <RefreshControl
+              refreshing={isRefetching}
+              onRefresh={() => void refetch()}
+            />
+          }
+          ListHeaderComponent={
+            <View className="flex-row px-4 mb-1">
+              <Text className="flex-1 text-slate-400 text-xs">Valutni par</Text>
+              <Text className="w-24 text-right text-slate-400 text-xs">
+                Kupovni
+              </Text>
+              <Text className="w-24 text-right text-slate-400 text-xs">
+                Prodajni
+              </Text>
+            </View>
+          }
+          renderItem={({ item }) => (
+            <Card>
+              <View className="flex-row items-center">
+                <View className="flex-1">
+                  <Text className="text-slate-900 font-medium">
+                    {currencyLabel(item.from)}/{currencyLabel(item.to)}
+                  </Text>
+                  {item.updatedAt ? (
+                    <Text className="text-slate-400 text-xs mt-0.5">
+                      {formatDateTime(item.updatedAt)}
+                    </Text>
+                  ) : null}
+                </View>
+                <Text className="w-24 text-right text-slate-900 font-mono">
+                  {formatRate(item.bid)}
+                </Text>
+                <Text className="w-24 text-right text-slate-900 font-mono">
+                  {formatRate(item.ask)}
+                </Text>
+              </View>
+            </Card>
+          )}
+        />
+      )}
+    </Screen>
+  );
+}

--- a/src/lib/api/cards.ts
+++ b/src/lib/api/cards.ts
@@ -1,0 +1,54 @@
+// Card reads + blocking (todoSpec mobile section). No new backend:
+// reuses the existing gateway endpoints the web app already drives.
+//   - GET  /v1/cards          ListCards (numbers come back masked for
+//                             clients)
+//   - POST /v1/cards/{id}/status  SetCardStatus
+//
+// Blocking only: the mobile client may BLOCK a card but never unblock
+// it — unblocking happens in branch / by phone (spec). The screen never
+// offers the reverse action.
+import { api } from "./client";
+import type {
+  v1Card,
+  v1ListCardsResponse,
+  v1ListTransactionsResponse,
+  BankServiceSetCardStatusBody,
+} from "./generated";
+import { v1CardStatus } from "./generated";
+
+export async function listCards(accountId?: string): Promise<v1Card[]> {
+  const { data } = await api.get<v1ListCardsResponse>("/v1/cards", {
+    params: accountId ? { accountId } : {},
+  });
+  return data.cards ?? [];
+}
+
+export async function setCardStatus(
+  id: string,
+  status: v1CardStatus,
+): Promise<v1Card> {
+  const body: BankServiceSetCardStatusBody = { status };
+  const { data } = await api.post<v1Card>(`/v1/cards/${id}/status`, body);
+  return data;
+}
+
+// blockCard is the only state transition the mobile app performs.
+export async function blockCard(id: string): Promise<v1Card> {
+  return setCardStatus(id, v1CardStatus.CARD_STATUS_BLOCKED);
+}
+
+// Per-card transaction history. The transactions endpoint filters by
+// account (there is no card_id filter — a card's ledger IS its
+// account's ledger), so we page over the card's account. Paginated for
+// readability on a phone.
+export async function listCardTransactions(
+  accountId: string,
+  page: number,
+  pageSize: number,
+): Promise<v1ListTransactionsResponse> {
+  const { data } = await api.get<v1ListTransactionsResponse>(
+    "/v1/transactions",
+    { params: { accountId, page, pageSize } },
+  );
+  return data;
+}

--- a/src/lib/api/exchange.ts
+++ b/src/lib/api/exchange.ts
@@ -1,0 +1,44 @@
+// Menjačnica (currency exchange, todoSpec mobile section). No new
+// backend. Two existing gateway endpoints, exactly as the web app's
+// menjačnica page uses them:
+//   - POST /v1/menjacnica/quote  QuoteExchange (rate + commission +
+//                                resulting amount; non-mutating)
+//   - POST /v1/transfers         CreateTransfer — the execute path. A
+//                                cross-currency transfer between two of
+//                                the client's OWN accounts IS the
+//                                menjačnica conversion (there is no
+//                                separate "execute exchange" route; the
+//                                bank routes the FX via RSD internally).
+//
+// CreateTransfer is verification-gated (spec p.11): the caller must
+// attach a VerificationProof (X-Verification-* headers). The screen
+// runs the spec-Option-1 round-trip: request a code, show it, confirm,
+// then call executeExchange with the proof.
+import { api } from "./client";
+import type {
+  v1QuoteExchangeRequest,
+  v1QuoteExchangeResponse,
+  v1CreateTransferRequest,
+  v1PaymentResult,
+} from "./generated";
+import { proofHeaders, type VerificationProof } from "./verification";
+
+export async function quoteExchange(
+  req: v1QuoteExchangeRequest,
+): Promise<v1QuoteExchangeResponse> {
+  const { data } = await api.post<v1QuoteExchangeResponse>(
+    "/v1/menjacnica/quote",
+    req,
+  );
+  return data;
+}
+
+export async function executeExchange(
+  req: v1CreateTransferRequest,
+  proof: VerificationProof,
+): Promise<v1PaymentResult> {
+  const { data } = await api.post<v1PaymentResult>("/v1/transfers", req, {
+    headers: proofHeaders(proof),
+  });
+  return data;
+}

--- a/src/lib/api/loans.ts
+++ b/src/lib/api/loans.ts
@@ -1,0 +1,24 @@
+// Loan reads (todoSpec mobile section). Read-only: the client views
+// their loans plus the upcoming installment amount + due date. Reuses
+// the existing gateway endpoints:
+//   - GET /v1/loans       ListLoans (filtered to the caller's loans by
+//                         the gateway's client scoping)
+//   - GET /v1/loans/{id}  GetLoan -> loan + full installment schedule
+import { api } from "./client";
+import type {
+  v1Loan,
+  v1ListLoansResponse,
+  v1LoanWithInstallments,
+} from "./generated";
+
+export async function listLoans(clientId?: string): Promise<v1Loan[]> {
+  const { data } = await api.get<v1ListLoansResponse>("/v1/loans", {
+    params: clientId ? { clientId } : {},
+  });
+  return data.loans ?? [];
+}
+
+export async function getLoan(id: string): Promise<v1LoanWithInstallments> {
+  const { data } = await api.get<v1LoanWithInstallments>(`/v1/loans/${id}`);
+  return data;
+}

--- a/src/lib/api/rates.ts
+++ b/src/lib/api/rates.ts
@@ -1,0 +1,10 @@
+// Exchange-rate list (kursna lista, todoSpec mobile section). Read-only.
+// Reuses the existing gateway endpoint GET /v1/exchange/rates
+// (ListRates) — the same one the web app's menjačnica page reads.
+import { api } from "./client";
+import type { v1Rate, v1ListRatesResponse } from "./generated";
+
+export async function listRates(): Promise<v1Rate[]> {
+  const { data } = await api.get<v1ListRatesResponse>("/v1/exchange/rates");
+  return data.rates ?? [];
+}

--- a/src/lib/api/verification.ts
+++ b/src/lib/api/verification.ts
@@ -55,3 +55,55 @@ export async function getVerificationHistory(): Promise<
   );
   return data.history ?? [];
 }
+
+// --- Inline-proof flow (spec p.11) -------------------------------------
+// Used by the menjačnica (currency-exchange) screen, the one mutating
+// action in the mobile app's todoSpec scope. The web app drives the
+// identical round-trip via its verification dialog: request a 6-digit
+// code, show it to the user, then attach it to the gated mutation as
+// X-Verification-* headers. For inline-delivery actions (transfer) the
+// gateway returns the code in the request response in dev mode, so the
+// phone can display it directly (same fake-QR substitute the web app
+// uses until the verification is consumed).
+
+export type VerificationKind =
+  | "payment"
+  | "transfer"
+  | "limit_change"
+  | "card_issue";
+
+export interface VerificationProof {
+  id: string;
+  code: string;
+}
+
+export interface IssuedVerification {
+  verificationId: string;
+  /** Present for inline-delivery actions (transfer/payment/limit). */
+  code: string;
+  expiresAt: string;
+  delivery: "inline" | "email";
+}
+
+export async function requestVerification(
+  actionKind: VerificationKind,
+): Promise<IssuedVerification> {
+  const { data } = await api.post<IssuedVerification>(
+    "/v1/verification/request",
+    { actionKind },
+  );
+  return data;
+}
+
+// proofHeaders maps a verification proof to the gateway middleware's
+// expected headers. Empty object when no proof so callers can spread
+// unconditionally.
+export function proofHeaders(
+  proof?: VerificationProof,
+): Record<string, string> {
+  if (!proof) return {};
+  return {
+    "X-Verification-Id": proof.id,
+    "X-Verification-Code": proof.code,
+  };
+}

--- a/src/lib/cards-meta.ts
+++ b/src/lib/cards-meta.ts
@@ -1,0 +1,33 @@
+// Serbian labels for card enums, shared by the kartice list + detail
+// screens. (The app keeps copy inline at call sites, but both screens
+// need the same status badge + brand name, so colocating the map here
+// keeps them in sync — and it lives under src/ so Expo Router doesn't
+// treat it as a route.)
+import type { BadgeTone } from "@/components/ui";
+import { v1CardBrand, v1CardStatus } from "@/lib/api/generated";
+
+export const statusMeta: Record<
+  v1CardStatus,
+  { label: string; tone: BadgeTone }
+> = {
+  [v1CardStatus.CARD_STATUS_UNSPECIFIED]: { label: "—", tone: "neutral" },
+  [v1CardStatus.CARD_STATUS_ACTIVE]: { label: "Aktivna", tone: "success" },
+  [v1CardStatus.CARD_STATUS_BLOCKED]: { label: "Blokirana", tone: "danger" },
+  [v1CardStatus.CARD_STATUS_DEACTIVATED]: {
+    label: "Deaktivirana",
+    tone: "neutral",
+  },
+};
+
+const brandNames: Record<v1CardBrand, string> = {
+  [v1CardBrand.CARD_BRAND_UNSPECIFIED]: "Kartica",
+  [v1CardBrand.CARD_BRAND_VISA]: "Visa",
+  [v1CardBrand.CARD_BRAND_MASTERCARD]: "Mastercard",
+  [v1CardBrand.CARD_BRAND_DINACARD]: "DinaCard",
+  [v1CardBrand.CARD_BRAND_AMEX]: "American Express",
+};
+
+export function brandLabel(brand: v1CardBrand | undefined): string {
+  if (!brand) return "Kartica";
+  return brandNames[brand] ?? "Kartica";
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -32,3 +32,21 @@ export function formatDateTime(iso: string | undefined): string {
   const mi = String(d.getMinutes()).padStart(2, "0");
   return `${formatDate(iso)} ${hh}:${mi}`;
 }
+
+// currencyLabel strips the proto enum prefix to the 3-letter ISO code
+// (CURRENCY_EUR -> "EUR"). Both bank + exchange Currency enums share the
+// same CURRENCY_* shape, so one helper covers both.
+export function currencyLabel(currency: string | undefined): string {
+  if (!currency) return "";
+  return currency.replace(/^CURRENCY_/, "");
+}
+
+// FX rates carry more precision than money; show up to 4 decimals.
+export function formatRate(rate: string | undefined): string {
+  const n = Number(rate ?? "0");
+  if (!Number.isFinite(n) || n === 0) return "—";
+  return new Intl.NumberFormat("sr-RS", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  }).format(n);
+}

--- a/src/lib/loans-meta.ts
+++ b/src/lib/loans-meta.ts
@@ -1,0 +1,55 @@
+// Serbian labels for loan enums, shared by the krediti list + detail
+// screens. Lives under src/ so Expo Router doesn't treat it as a route.
+import type { BadgeTone } from "@/components/ui";
+import {
+  v1InstallmentStatus,
+  v1LoanStatus,
+  v1LoanType,
+} from "@/lib/api/generated";
+
+export const loanStatusMeta: Record<
+  v1LoanStatus,
+  { label: string; tone: BadgeTone }
+> = {
+  [v1LoanStatus.LOAN_STATUS_UNSPECIFIED]: { label: "—", tone: "neutral" },
+  [v1LoanStatus.LOAN_STATUS_APPROVED]: { label: "Aktivan", tone: "success" },
+  [v1LoanStatus.LOAN_STATUS_REJECTED]: { label: "Odbijen", tone: "danger" },
+  [v1LoanStatus.LOAN_STATUS_PAID_OFF]: { label: "Otplaćen", tone: "neutral" },
+  [v1LoanStatus.LOAN_STATUS_OVERDUE]: { label: "U docnji", tone: "warning" },
+};
+
+const loanTypeNames: Record<v1LoanType, string> = {
+  [v1LoanType.LOAN_TYPE_UNSPECIFIED]: "Kredit",
+  [v1LoanType.LOAN_TYPE_CASH]: "Gotovinski kredit",
+  [v1LoanType.LOAN_TYPE_HOUSING]: "Stambeni kredit",
+  [v1LoanType.LOAN_TYPE_AUTO]: "Auto kredit",
+  [v1LoanType.LOAN_TYPE_REFINANCE]: "Kredit za refinansiranje",
+  [v1LoanType.LOAN_TYPE_STUDENT]: "Studentski kredit",
+};
+
+export function loanTypeLabel(type: v1LoanType | undefined): string {
+  if (!type) return "Kredit";
+  return loanTypeNames[type] ?? "Kredit";
+}
+
+export const installmentStatusMeta: Record<
+  v1InstallmentStatus,
+  { label: string; tone: BadgeTone }
+> = {
+  [v1InstallmentStatus.INSTALLMENT_STATUS_UNSPECIFIED]: {
+    label: "—",
+    tone: "neutral",
+  },
+  [v1InstallmentStatus.INSTALLMENT_STATUS_PAID]: {
+    label: "Plaćena",
+    tone: "success",
+  },
+  [v1InstallmentStatus.INSTALLMENT_STATUS_UNPAID]: {
+    label: "Neplaćena",
+    tone: "info",
+  },
+  [v1InstallmentStatus.INSTALLMENT_STATUS_OVERDUE]: {
+    label: "U docnji",
+    tone: "warning",
+  },
+};

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -18,4 +18,22 @@ export const keys = {
     // Durable request history (spec p.84 "Stranica Verifikacija").
     history: () => ["verification", "history"] as const,
   },
+  cards: {
+    all: () => ["cards"] as const,
+    list: () => ["cards", "list"] as const,
+    transactions: (accountId: string, page: number) =>
+      ["cards", accountId, "transactions", page] as const,
+  },
+  rates: {
+    all: () => ["rates"] as const,
+  },
+  loans: {
+    all: () => ["loans"] as const,
+    list: () => ["loans", "list"] as const,
+    detail: (id: string) => ["loans", "detail", id] as const,
+  },
+  exchange: {
+    quote: (from: string, to: string, amount: string) =>
+      ["exchange", "quote", from, to, amount] as const,
+  },
 } as const;


### PR DESCRIPTION
Mobile "Proširenje za mobilne aplikacije": card list + block (block-only), per-card transactions, menjačnica (verification-gated), kursna lista, loan installments. Frontend-only, reuses existing gateway endpoints. typecheck clean. Quick Approve + rate-history deferred (need backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)