### PR TITLE
feat(menjacnica): last-month FX rate history view (todoSpec)

### DIFF
--- a/app/(app)/menjacnica/_layout.tsx
+++ b/app/(app)/menjacnica/_layout.tsx
@@ -5,6 +5,7 @@ export default function MenjacnicaLayout() {
     <Stack screenOptions={{ headerStyle: { backgroundColor: "#f8fafc" } }}>
       <Stack.Screen name="index" options={{ title: "Menjačnica" }} />
       <Stack.Screen name="kursna-lista" options={{ title: "Kursna lista" }} />
+      <Stack.Screen name="istorija" options={{ title: "Istorija kursa" }} />
     </Stack>
   );
 }

--- a/app/(app)/menjacnica/istorija.tsx
+++ b/app/(app)/menjacnica/istorija.tsx
@@ -1,0 +1,106 @@
+import { FlatList, RefreshControl, Text, View } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import { useQuery } from "@tanstack/react-query";
+
+import { listRateHistory } from "@/lib/api/rates";
+import { keys } from "@/lib/query-keys";
+import { currencyLabel, formatDateTime, formatRate } from "@/lib/format";
+import { Card, LoadingState, MessageState, Screen } from "@/components/ui";
+import { bankaExchangeV1Currency } from "@/lib/api/generated";
+
+// Kursna lista — zadnjih mesec dana (todoSpec mobile). Recorded bid/ask
+// points for one pair over the last 30 days, newest first. Read-only;
+// reuses GET /v1/exchange/rates/history (ListRateHistory). History
+// accrues from the running FX feed, so a fresh stack starts empty and
+// fills in over time.
+const HISTORY_DAYS = 30;
+
+function asCurrency(v: string | undefined): bankaExchangeV1Currency {
+  return (v ?? "CURRENCY_UNSPECIFIED") as bankaExchangeV1Currency;
+}
+
+export default function KursnaListaIstorijaScreen() {
+  const params = useLocalSearchParams<{ from?: string; to?: string }>();
+  const from = asCurrency(params.from);
+  const to = asCurrency(params.to);
+  const valid =
+    from !== bankaExchangeV1Currency.CURRENCY_UNSPECIFIED &&
+    to !== bankaExchangeV1Currency.CURRENCY_UNSPECIFIED;
+
+  const { data, isLoading, isError, isRefetching, refetch } = useQuery({
+    queryKey: keys.rates.history(from, to, HISTORY_DAYS),
+    queryFn: () => listRateHistory(from, to, HISTORY_DAYS),
+    enabled: valid,
+  });
+
+  if (!valid)
+    return (
+      <Screen>
+        <MessageState message="Valutni par nije prepoznat." />
+      </Screen>
+    );
+
+  if (isLoading) return <LoadingState />;
+  if (isError)
+    return (
+      <Screen>
+        <MessageState message="Istorija kursa trenutno nije dostupna." />
+      </Screen>
+    );
+
+  const points = data ?? [];
+
+  return (
+    <Screen>
+      <Card>
+        <Text className="text-slate-900 font-medium">
+          {currencyLabel(from)}/{currencyLabel(to)}
+        </Text>
+        <Text className="text-slate-400 text-xs mt-0.5">
+          Kurs u zadnjih mesec dana
+        </Text>
+      </Card>
+
+      {points.length === 0 ? (
+        <MessageState message="Nema zabeleženih kurseva za izabrani period." />
+      ) : (
+        <FlatList
+          data={points}
+          keyExtractor={(p, i) => `${p.recordedAt ?? ""}-${i}`}
+          refreshControl={
+            <RefreshControl
+              refreshing={isRefetching}
+              onRefresh={() => void refetch()}
+            />
+          }
+          ListHeaderComponent={
+            <View className="flex-row px-4 mb-1">
+              <Text className="flex-1 text-slate-400 text-xs">Datum</Text>
+              <Text className="w-24 text-right text-slate-400 text-xs">
+                Kupovni
+              </Text>
+              <Text className="w-24 text-right text-slate-400 text-xs">
+                Prodajni
+              </Text>
+            </View>
+          }
+          renderItem={({ item }) => (
+            <Card>
+              <View className="flex-row items-center">
+                <Text className="flex-1 text-slate-700 text-xs">
+                  {formatDateTime(item.recordedAt)}
+                </Text>
+                <Text className="w-24 text-right text-slate-900 font-mono">
+                  {formatRate(item.bid)}
+                </Text>
+                <Text className="w-24 text-right text-slate-900 font-mono">
+                  {formatRate(item.ask)}
+                </Text>
+              </View>
+            </Card>
+          )}
+        />
+      )}
+    </Screen>
+  );
+}

--- a/app/(app)/menjacnica/kursna-lista.tsx
+++ b/app/(app)/menjacnica/kursna-lista.tsx
@@ -1,4 +1,11 @@
-import { FlatList, RefreshControl, Text, View } from "react-native";
+import {
+  FlatList,
+  Pressable,
+  RefreshControl,
+  Text,
+  View,
+} from "react-native";
+import { Link } from "expo-router";
 import { useQuery } from "@tanstack/react-query";
 
 import { listRates } from "@/lib/api/rates";
@@ -56,26 +63,33 @@ export default function KursnaListaScreen() {
             </View>
           }
           renderItem={({ item }) => (
-            <Card>
-              <View className="flex-row items-center">
-                <View className="flex-1">
-                  <Text className="text-slate-900 font-medium">
-                    {currencyLabel(item.from)}/{currencyLabel(item.to)}
-                  </Text>
-                  {item.updatedAt ? (
-                    <Text className="text-slate-400 text-xs mt-0.5">
-                      {formatDateTime(item.updatedAt)}
+            <Link
+              href={`/(app)/menjacnica/istorija?from=${item.from}&to=${item.to}`}
+              asChild
+            >
+              <Pressable>
+                <Card>
+                  <View className="flex-row items-center">
+                    <View className="flex-1">
+                      <Text className="text-slate-900 font-medium">
+                        {currencyLabel(item.from)}/{currencyLabel(item.to)}
+                      </Text>
+                      {item.updatedAt ? (
+                        <Text className="text-slate-400 text-xs mt-0.5">
+                          {formatDateTime(item.updatedAt)}
+                        </Text>
+                      ) : null}
+                    </View>
+                    <Text className="w-24 text-right text-slate-900 font-mono">
+                      {formatRate(item.bid)}
                     </Text>
-                  ) : null}
-                </View>
-                <Text className="w-24 text-right text-slate-900 font-mono">
-                  {formatRate(item.bid)}
-                </Text>
-                <Text className="w-24 text-right text-slate-900 font-mono">
-                  {formatRate(item.ask)}
-                </Text>
-              </View>
-            </Card>
+                    <Text className="w-24 text-right text-slate-900 font-mono">
+                      {formatRate(item.ask)}
+                    </Text>
+                  </View>
+                </Card>
+              </Pressable>
+            </Link>
           )}
         />
       )}

--- a/src/lib/api/generated/index.ts
+++ b/src/lib/api/generated/index.ts
@@ -117,6 +117,7 @@ export type { v1ListOTCContractsResponse } from './models/v1ListOTCContractsResp
 export type { v1ListOTCThreadsResponse } from './models/v1ListOTCThreadsResponse';
 export type { v1ListPaymentRecipientsResponse } from './models/v1ListPaymentRecipientsResponse';
 export type { v1ListPublicHoldingsResponse } from './models/v1ListPublicHoldingsResponse';
+export type { v1ListRateHistoryResponse } from './models/v1ListRateHistoryResponse';
 export type { v1ListRatesResponse } from './models/v1ListRatesResponse';
 export type { v1ListRealizedPnLResponse } from './models/v1ListRealizedPnLResponse';
 export type { v1ListSecuritiesResponse } from './models/v1ListSecuritiesResponse';
@@ -149,6 +150,7 @@ export type { v1PublicHoldingItem } from './models/v1PublicHoldingItem';
 export type { v1QuoteExchangeRequest } from './models/v1QuoteExchangeRequest';
 export type { v1QuoteExchangeResponse } from './models/v1QuoteExchangeResponse';
 export type { v1Rate } from './models/v1Rate';
+export type { v1RateHistoryPoint } from './models/v1RateHistoryPoint';
 export type { v1RealizedPnLRow } from './models/v1RealizedPnLRow';
 export type { v1RefreshRequest } from './models/v1RefreshRequest';
 export type { v1RefreshResponse } from './models/v1RefreshResponse';

--- a/src/lib/api/generated/models/v1ListRateHistoryResponse.ts
+++ b/src/lib/api/generated/models/v1ListRateHistoryResponse.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { bankaExchangeV1Currency } from './bankaExchangeV1Currency';
+import type { v1RateHistoryPoint } from './v1RateHistoryPoint';
+export type v1ListRateHistoryResponse = {
+    from?: bankaExchangeV1Currency;
+    to?: bankaExchangeV1Currency;
+    /**
+     * points are ordered newest first.
+     */
+    points?: Array<v1RateHistoryPoint>;
+};
+

--- a/src/lib/api/generated/models/v1RateHistoryPoint.ts
+++ b/src/lib/api/generated/models/v1RateHistoryPoint.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type v1RateHistoryPoint = {
+    bid?: string;
+    ask?: string;
+    recordedAt?: string;
+};
+

--- a/src/lib/api/rates.ts
+++ b/src/lib/api/rates.ts
@@ -2,9 +2,31 @@
 // Reuses the existing gateway endpoint GET /v1/exchange/rates
 // (ListRates) — the same one the web app's menjačnica page reads.
 import { api } from "./client";
-import type { v1Rate, v1ListRatesResponse } from "./generated";
+import type {
+  v1Rate,
+  v1ListRatesResponse,
+  v1RateHistoryPoint,
+  v1ListRateHistoryResponse,
+  bankaExchangeV1Currency,
+} from "./generated";
 
 export async function listRates(): Promise<v1Rate[]> {
   const { data } = await api.get<v1ListRatesResponse>("/v1/exchange/rates");
   return data.rates ?? [];
+}
+
+// listRateHistory backs the "kursna lista u zadnjih mesec dana" view —
+// recorded bid/ask points for one pair over the last `days` days
+// (default 30), newest first. Reuses GET /v1/exchange/rates/history
+// (ListRateHistory), the append-only sibling of ListRates.
+export async function listRateHistory(
+  from: bankaExchangeV1Currency,
+  to: bankaExchangeV1Currency,
+  days = 30,
+): Promise<v1RateHistoryPoint[]> {
+  const { data } = await api.get<v1ListRateHistoryResponse>(
+    "/v1/exchange/rates/history",
+    { params: { from, to, days } },
+  );
+  return data.points ?? [];
 }

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -26,6 +26,8 @@ export const keys = {
   },
   rates: {
     all: () => ["rates"] as const,
+    history: (from: string, to: string, days: number) =>
+      ["rates", "history", from, to, days] as const,
   },
   loans: {
     all: () => ["loans"] as const,


### PR DESCRIPTION
Tap a pair on kursna-lista → last-30-days history (date/kupovni/prodajni). Uses the new exchange ListRateHistory endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)